### PR TITLE
Add `stats` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,10 @@ Available Commands:
   fmt         Normalize CODEOWNERS format
   help        Help about any command
   lint        Validate codeowners file
+  stats       Display code ownership statistics
   version     Print code version
   who         List code owners for file(s)
-  why         Show rule used for a file
+  why         Identify which rule effects ownership for a single file.
 
 Flags:
   -f, --file string   CODEOWNERS file path

--- a/cmd/co/main.go
+++ b/cmd/co/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"os"
 
-	"github.com/lukealbao/co"
+	codeowners "github.com/lukealbao/co"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/co/main.go
+++ b/cmd/co/main.go
@@ -52,7 +52,7 @@ func init() {
 
 	root.AddCommand(whyCmd)
 
-	statsCmd.Flags().BoolP("json", "j", false, "format output as json. output is Array<{owner: string; fileCount: number, percentage: number}>.")
+	statsCmd.Flags().BoolP("json", "j", false, "format output as json")
 	root.AddCommand(statsCmd)
 
 	diffCmd.Flags().BoolP("renames", "r", false, "follow file renames")

--- a/cmd/co/main.go
+++ b/cmd/co/main.go
@@ -46,12 +46,14 @@ func init() {
 	whoCmd.Flags().StringSliceVarP(&ownerFilters, "owner", "o", nil, "filter results by owner")
 	whoCmd.Flags().BoolVarP(&showUnowned, "unowned", "u", false, "only show unowned files (can be combined with -o)")
 	whoCmd.Flags().BoolP("json", "j", false, "format output as json. output is Array<{path: string; owners: Array<string>}>.")
-	whoCmd.Flags().BoolP("stats", "s", false, "display ownership statistics")
+	root.AddCommand(whoCmd)
 
 	whyCmd.Flags().BoolP("json", "j", false, "format output as json. output is {path: string; line: string; rule: string; owners: Array<string>}.")
 
-	root.AddCommand(whoCmd)
 	root.AddCommand(whyCmd)
+
+	statsCmd.Flags().BoolP("json", "j", false, "format output as json. output is Array<{owner: string; fileCount: number}>.")
+	root.AddCommand(statsCmd)
 
 	diffCmd.Flags().BoolP("renames", "r", false, "follow file renames")
 	root.AddCommand(diffCmd)

--- a/cmd/co/main.go
+++ b/cmd/co/main.go
@@ -52,7 +52,7 @@ func init() {
 
 	root.AddCommand(whyCmd)
 
-	statsCmd.Flags().BoolP("json", "j", false, "format output as json. output is Array<{owner: string; fileCount: number}>.")
+	statsCmd.Flags().BoolP("json", "j", false, "format output as json. output is Array<{owner: string; fileCount: number, percentage: number}>.")
 	root.AddCommand(statsCmd)
 
 	diffCmd.Flags().BoolP("renames", "r", false, "follow file renames")

--- a/cmd/co/main.go
+++ b/cmd/co/main.go
@@ -46,6 +46,7 @@ func init() {
 	whoCmd.Flags().StringSliceVarP(&ownerFilters, "owner", "o", nil, "filter results by owner")
 	whoCmd.Flags().BoolVarP(&showUnowned, "unowned", "u", false, "only show unowned files (can be combined with -o)")
 	whoCmd.Flags().BoolP("json", "j", false, "format output as json. output is Array<{path: string; owners: Array<string>}>.")
+	whoCmd.Flags().BoolP("stats", "s", false, "display ownership statistics")
 
 	whyCmd.Flags().BoolP("json", "j", false, "format output as json. output is {path: string; line: string; rule: string; owners: Array<string>}.")
 

--- a/cmd/co/stats.go
+++ b/cmd/co/stats.go
@@ -10,10 +10,12 @@ import (
 
 var statsCmd = &cobra.Command{
 	Use:   "stats [filepath]...",
-	Short: "List code ownership statistics for file(s)",
-	Long: `List code ownership statistics for file(s)
+	Short: "Display code ownership statistics",
+	Long: `Display code ownership statistics
 
 Total files, owned files, unowned files, and owner count are displayed.
+
+If filepaths are provided, only files matching the provided paths are considered.
 
 Per owner file count and percentage are also displayed, sorted by file count.
 Unowned files are displayed as belonging to the dummy "(unowned)" group.

--- a/cmd/co/stats.go
+++ b/cmd/co/stats.go
@@ -34,7 +34,7 @@ Note that unowned files are displayed as belonging to the dummy "(unowned)" grou
 
 		stats := codeowners.CalculateOwnershipStats(files)
 		if formatJson {
-			bytes, err := json.MarshalIndent(stats.FilesPerOwner, "", "  ")
+			bytes, err := json.MarshalIndent(stats, "", "  ")
 			exitIf(err)
 
 			fmt.Fprintf(cmd.OutOrStdout(), "%s\n", bytes)

--- a/cmd/co/stats.go
+++ b/cmd/co/stats.go
@@ -13,14 +13,21 @@ var statsCmd = &cobra.Command{
 	Short: "Display code ownership statistics",
 	Long: `Display code ownership statistics
 
-Total files, owned files, unowned files, and owner count are displayed.
+Default format displays a table:
+
+  Total files                    5 (100.00%)
+  Owned files                    2 (40.00%)
+  Unowned files                  3 (60.00%)
+  Owner count                    2
+  ----------------------------------------------
+  (unowned)                                          3 (60.00%)
+  owner-a                                            2 (40.00%)
+  owner-b                                            1 (20.00%)
+
+Unowned files are displayed as belonging to the dummy "(unowned)" group.
+Ownership percentages may add up to more than 100%, as there can be more than one owner per file.
 
 If filepaths are provided, only files matching the provided paths are considered.
-
-Per owner file count and percentage are also displayed, sorted by file count.
-Unowned files are displayed as belonging to the dummy "(unowned)" group.
-
-Ownership percentages may add up to more than 100%, as there can be more than one owner per file.
 `,
 	Run: func(cmd *cobra.Command, args []string) {
 		var err error
@@ -56,12 +63,12 @@ func displayOwnershipStats(stats codeowners.OwnerStats) {
 	ownedCount := float64(stats.OwnedFiles)
 	unownedCount := float64(stats.UnownedFiles)
 	filesPerOwner := stats.FilesPerOwner
-	totalOwners := stats.TotalOwners
+	totalOwners := stats.OwnerCount
 
 	fmt.Printf("%-30s %.0f (%.2f%%)\n", "Total files", fileCount, (fileCount/fileCount)*100)
-	fmt.Printf("%-30s %.0f (%.2f%%)\n", "Total files with owners", ownedCount, (ownedCount/fileCount)*100)
-	fmt.Printf("%-30s %.0f (%.2f%%)\n", "Total unowned files", unownedCount, (unownedCount/fileCount)*100)
-	fmt.Printf("%-30s %d\n", "Total owners", totalOwners)
+	fmt.Printf("%-30s %.0f (%.2f%%)\n", "Owned files", ownedCount, (ownedCount/fileCount)*100)
+	fmt.Printf("%-30s %.0f (%.2f%%)\n", "Unowned files", unownedCount, (unownedCount/fileCount)*100)
+	fmt.Printf("%-30s %d\n", "Owner count", totalOwners)
 	fmt.Println("----------------------------------------------")
 	for _, kv := range filesPerOwner {
 		fmt.Printf("%-50s %d (%.2f%%)\n", kv.Owner, kv.Count, kv.Percentage)

--- a/cmd/co/stats.go
+++ b/cmd/co/stats.go
@@ -11,7 +11,11 @@ import (
 var statsCmd = &cobra.Command{
 	Use:   "stats [filepath]...",
 	Short: "List code ownership statistics for file(s)",
-	Long: `List code owners for file(s)
+	Long: `List code ownership statistics for file(s)
+
+Total files, owned files, unowned files, and owners are displayed.
+
+Per owner file count and percentage are also displayed, sorted by file count.
 
 Note that unowned files are displayed as belonging to the dummy "(unowned)" group.
 `,

--- a/cmd/co/stats.go
+++ b/cmd/co/stats.go
@@ -13,7 +13,7 @@ var statsCmd = &cobra.Command{
 	Short: "List code ownership statistics for file(s)",
 	Long: `List code ownership statistics for file(s)
 
-Total files, owned files, unowned files, and owners are displayed.
+Total files, owned files, unowned files, and owner count are displayed.
 
 Per owner file count and percentage are also displayed, sorted by file count.
 

--- a/cmd/co/stats.go
+++ b/cmd/co/stats.go
@@ -30,7 +30,7 @@ Note that unowned files are displayed as belonging to the dummy "(unowned)" grou
 		formatJson, err := cmd.Flags().GetBool("json")
 		exitIf(err)
 
-		files, err := listOwners(sessionRules, filesToCheck, ownerFilters, showUnowned)
+		files, err := codeowners.ListOwners(sessionRules, filesToCheck, ownerFilters, showUnowned)
 		exitIf(err)
 
 		stats := calculateOwnershipStats(files)
@@ -59,7 +59,7 @@ type OwnerStats struct {
 	filesPerOwner []FilesPerOwner
 }
 
-func calculateOwnershipStats(files []*r) OwnerStats {
+func calculateOwnershipStats(files codeowners.Owners) OwnerStats {
 	fileCount := len(files)
 
 	stats := make(map[string]int)

--- a/cmd/co/stats.go
+++ b/cmd/co/stats.go
@@ -55,12 +55,12 @@ func displayOwnershipStats(stats codeowners.OwnerStats) {
 	filesPerOwner := stats.FilesPerOwner
 	totalOwners := stats.TotalOwners
 
-	fmt.Printf("Total files: %.0f (%.2f%%)\n", fileCount, (fileCount/fileCount)*100)
-	fmt.Printf("Total files with owners: %.0f (%.2f%%)\n", ownedCount, (ownedCount/fileCount)*100)
-	fmt.Printf("Total unowned files: %.0f (%.2f%%)\n", unownedCount, (unownedCount/fileCount)*100)
-	fmt.Printf("Total owners: %d\n", totalOwners)
-	fmt.Println()
+	fmt.Printf("%-30s %.0f (%.2f%%)\n", "Total files", fileCount, (fileCount/fileCount)*100)
+	fmt.Printf("%-30s %.0f (%.2f%%)\n", "Total files with owners", ownedCount, (ownedCount/fileCount)*100)
+	fmt.Printf("%-30s %.0f (%.2f%%)\n", "Total unowned files", unownedCount, (unownedCount/fileCount)*100)
+	fmt.Printf("%-30s %d\n", "Total owners", totalOwners)
+	fmt.Println("----------------------------------------------")
 	for _, kv := range filesPerOwner {
-		fmt.Printf("%s: %d (%.2f%%)\n", kv.Owner, kv.Count, kv.Percentage)
+		fmt.Printf("%-50s %d (%.2f%%)\n", kv.Owner, kv.Count, kv.Percentage)
 	}
 }

--- a/cmd/co/stats.go
+++ b/cmd/co/stats.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+
+	codeowners "github.com/lukealbao/co"
+	"github.com/spf13/cobra"
+)
+
+var statsCmd = &cobra.Command{
+	Use:   "stats [filepath]...",
+	Short: "List code ownership statistics for file(s)",
+	Long: `List code owners for file(s)
+
+Note that unowned files are displayed as belonging to the dummy "(unowned)" group.
+`,
+	Run: func(cmd *cobra.Command, args []string) {
+		var err error
+		var filesToCheck []string
+
+		if len(args) > 0 {
+			filesToCheck = expandAllFiles(args[:])
+		} else {
+			filesToCheck, err = codeowners.LsFiles("HEAD")
+			exitIf(err)
+		}
+
+		formatJson, err := cmd.Flags().GetBool("json")
+		exitIf(err)
+
+		files, err := listOwners(sessionRules, filesToCheck, ownerFilters, showUnowned)
+		exitIf(err)
+
+		stats := calculateOwnershipStats(files)
+		if formatJson {
+			bytes, err := json.MarshalIndent(stats.filesPerOwner, "", "  ")
+			exitIf(err)
+
+			fmt.Fprintf(cmd.OutOrStdout(), "%s\n", bytes)
+		} else {
+			displayOwnershipStats(stats)
+		}
+	},
+}
+
+type FilesPerOwner struct {
+	Owner      string  `json:"owner"`
+	Count      int     `json:"fileCount"`
+	Percentage float64 `json:"percentage"`
+}
+
+type OwnerStats struct {
+	totalFiles    int
+	ownedFiled    int
+	unownedFiles  int
+	totalOwners   int
+	filesPerOwner []FilesPerOwner
+}
+
+func calculateOwnershipStats(files []*r) OwnerStats {
+	fileCount := len(files)
+
+	stats := make(map[string]int)
+	for _, file := range files {
+		for _, owner := range file.Owners {
+			stats[owner]++
+		}
+	}
+
+	var filesPerOwner []FilesPerOwner
+	for owner, count := range stats {
+		percentage := (float64(count) / float64(fileCount)) * 100
+		filesPerOwner = append(filesPerOwner, FilesPerOwner{owner, count, percentage})
+	}
+
+	sort.Slice(filesPerOwner, func(i, j int) bool {
+		return filesPerOwner[i].Count > filesPerOwner[j].Count
+	})
+
+	unownedCount := stats["(unowned)"]
+	ownedCount := fileCount - unownedCount
+	totalOwners := len(stats) - 1
+
+	return OwnerStats{
+		totalFiles:    fileCount,
+		ownedFiled:    ownedCount,
+		unownedFiles:  unownedCount,
+		filesPerOwner: filesPerOwner,
+		totalOwners:   totalOwners,
+	}
+}
+
+func displayOwnershipStats(stats OwnerStats) {
+	fileCount := float64(stats.totalFiles)
+	ownedCount := float64(stats.ownedFiled)
+	unownedCount := float64(stats.unownedFiles)
+	filesPerOwner := stats.filesPerOwner
+	totalOwners := stats.totalOwners
+
+	fmt.Printf("Total files: %.0f (%.2f%%)\n", fileCount, (fileCount/fileCount)*100)
+	fmt.Printf("Total files with owners: %.0f (%.2f%%)\n", ownedCount, (ownedCount/fileCount)*100)
+	fmt.Printf("Total unowned files: %.0f (%.2f%%)\n", unownedCount, (unownedCount/fileCount)*100)
+	fmt.Printf("Total owners: %d\n", totalOwners)
+	fmt.Println()
+	for _, kv := range filesPerOwner {
+		fmt.Printf("%s: %d (%.2f%%)\n", kv.Owner, kv.Count, kv.Percentage)
+	}
+}

--- a/cmd/co/stats.go
+++ b/cmd/co/stats.go
@@ -16,8 +16,9 @@ var statsCmd = &cobra.Command{
 Total files, owned files, unowned files, and owner count are displayed.
 
 Per owner file count and percentage are also displayed, sorted by file count.
+Unowned files are displayed as belonging to the dummy "(unowned)" group.
 
-Note that unowned files are displayed as belonging to the dummy "(unowned)" group.
+Ownership percentages may add up to more than 100%, as there can be more than one owner per file.
 `,
 	Run: func(cmd *cobra.Command, args []string) {
 		var err error

--- a/cmd/co/stats.go
+++ b/cmd/co/stats.go
@@ -46,7 +46,7 @@ Note that unowned files are displayed as belonging to the dummy "(unowned)" grou
 
 func displayOwnershipStats(stats codeowners.OwnerStats) {
 	fileCount := float64(stats.TotalFiles)
-	ownedCount := float64(stats.OwnedFiled)
+	ownedCount := float64(stats.OwnedFiles)
 	unownedCount := float64(stats.UnownedFiles)
 	filesPerOwner := stats.FilesPerOwner
 	totalOwners := stats.TotalOwners

--- a/cmd/co/who.go
+++ b/cmd/co/who.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"sort"
 
 	"github.com/lukealbao/co"
 	"github.com/spf13/cobra"
@@ -57,13 +56,6 @@ JSON-formatted output displays an array of objects. Unowned files have a null ow
 		files, err := listOwners(sessionRules, filesToCheck, ownerFilters, showUnowned)
 		exitIf(err)
 
-		displayStats, err := cmd.Flags().GetBool("stats")
-		exitIf(err)
-		if displayStats {
-			displayOwnershipStats(files)
-			return
-		}
-
 		formatJson, err := cmd.Flags().GetBool("json")
 		exitIf(err)
 
@@ -79,46 +71,6 @@ JSON-formatted output displays an array of objects. Unowned files have a null ow
 			fmt.Fprintf(cmd.OutOrStdout(), "%-70s %s\n", result.Path, result.Owners)
 		}
 	},
-}
-
-func displayOwnershipStats(files []*r) {
-	stats := make(map[string]int)
-	for _, file := range files {
-		for _, owner := range file.Owners {
-			stats[owner]++
-		}
-	}
-
-	fileCount := float64(len(files))
-	unownedCount := float64(stats["(unowned)"])
-	ownedCount := float64(fileCount - unownedCount)
-
-	fmt.Printf("Total files: %.0f (%.2f%%)\n", fileCount, (fileCount/fileCount)*100)
-	fmt.Printf("Total files with owners: %.0f (%.2f%%)\n", ownedCount, (ownedCount/fileCount)*100)
-	fmt.Printf("Total unowned files: %.0f (%.2f%%)\n", unownedCount, (unownedCount/fileCount)*100)
-	fmt.Printf("Total owners: %d\n", len(stats)-1)
-
-	fmt.Println()
-
-	// sort owners by count
-	type FilesPerOwner struct {
-		Owner string
-		Count int
-	}
-
-	var ss []FilesPerOwner
-	for Owner, Count := range stats {
-		ss = append(ss, FilesPerOwner{Owner, Count})
-	}
-
-	sort.Slice(ss, func(i, j int) bool {
-		return ss[i].Count > ss[j].Count
-	})
-
-	for _, kv := range ss {
-		percentage := (float64(kv.Count) / fileCount) * 100
-		fmt.Printf("%s: %d (%.2f%%)\n", kv.Owner, kv.Count, percentage)
-	}
 }
 
 func expandAllFiles(paths []string) []string {

--- a/cmd/co/who.go
+++ b/cmd/co/who.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 
 	"github.com/lukealbao/co"
 	"github.com/spf13/cobra"
@@ -56,6 +57,13 @@ JSON-formatted output displays an array of objects. Unowned files have a null ow
 		files, err := listOwners(sessionRules, filesToCheck, ownerFilters, showUnowned)
 		exitIf(err)
 
+		displayStats, err := cmd.Flags().GetBool("stats")
+		exitIf(err)
+		if displayStats {
+			displayOwnershipStats(files)
+			return
+		}
+
 		formatJson, err := cmd.Flags().GetBool("json")
 		exitIf(err)
 
@@ -71,6 +79,46 @@ JSON-formatted output displays an array of objects. Unowned files have a null ow
 			fmt.Fprintf(cmd.OutOrStdout(), "%-70s %s\n", result.Path, result.Owners)
 		}
 	},
+}
+
+func displayOwnershipStats(files []*r) {
+	stats := make(map[string]int)
+	for _, file := range files {
+		for _, owner := range file.Owners {
+			stats[owner]++
+		}
+	}
+
+	fileCount := float64(len(files))
+	unownedCount := float64(stats["(unowned)"])
+	ownedCount := float64(fileCount - unownedCount)
+
+	fmt.Printf("Total files: %.0f (%.2f%%)\n", fileCount, (fileCount/fileCount)*100)
+	fmt.Printf("Total files with owners: %.0f (%.2f%%)\n", ownedCount, (ownedCount/fileCount)*100)
+	fmt.Printf("Total unowned files: %.0f (%.2f%%)\n", unownedCount, (unownedCount/fileCount)*100)
+	fmt.Printf("Total owners: %d\n", len(stats)-1)
+
+	fmt.Println()
+
+	// sort owners by count
+	type FilesPerOwner struct {
+		Owner string
+		Count int
+	}
+
+	var ss []FilesPerOwner
+	for Owner, Count := range stats {
+		ss = append(ss, FilesPerOwner{Owner, Count})
+	}
+
+	sort.Slice(ss, func(i, j int) bool {
+		return ss[i].Count > ss[j].Count
+	})
+
+	for _, kv := range ss {
+		percentage := (float64(kv.Count) / fileCount) * 100
+		fmt.Printf("%s: %d (%.2f%%)\n", kv.Owner, kv.Count, percentage)
+	}
 }
 
 func expandAllFiles(paths []string) []string {

--- a/cmd/co/who.go
+++ b/cmd/co/who.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/lukealbao/co"
+	codeowners "github.com/lukealbao/co"
 	"github.com/spf13/cobra"
 )
 
@@ -53,7 +53,7 @@ JSON-formatted output displays an array of objects. Unowned files have a null ow
 			exitIf(err)
 		}
 
-		files, err := listOwners(sessionRules, filesToCheck, ownerFilters, showUnowned)
+		files, err := codeowners.ListOwners(sessionRules, filesToCheck, ownerFilters, showUnowned)
 		exitIf(err)
 
 		formatJson, err := cmd.Flags().GetBool("json")

--- a/list.go
+++ b/list.go
@@ -1,0 +1,59 @@
+package codeowners
+
+import (
+	"sort"
+)
+
+type r struct {
+	Path   string   `json:"path"`
+	Owners []string `json:"owners"`
+}
+
+type Owners []*r
+
+func (x Owners) Len() int           { return len(x) }
+func (x Owners) Less(a, b int) bool { return x[a].Path < x[b].Path }
+func (x Owners) Swap(a, b int) {
+	x[a], x[b] = x[b], x[a]
+}
+
+var _ sort.Interface = (Owners)(nil)
+
+// ListOwners returns a list of structured output. Callers must format for printing.
+func ListOwners(rules Ruleset, files []string, ownerFilters []string, showUnowned bool) (Owners, error) {
+	var out []*r = make([]*r, 0)
+
+	for _, file := range files {
+		rule, err := rules.Match(file)
+		if err != nil {
+			return nil, err
+		}
+
+		if rule == nil || rule.Owners == nil || len(rule.Owners) == 0 {
+			if len(ownerFilters) == 0 || showUnowned {
+				out = append(out, &r{Path: file, Owners: []string{"(unowned)"}})
+			}
+
+			continue
+		}
+
+		owners := make([]string, 0, len(rule.Owners))
+		for _, owner := range rule.Owners {
+			filterMatch := len(ownerFilters) == 0 && !showUnowned
+			for _, filter := range ownerFilters {
+				if filter == owner { // TODO: This is "Value" in hmarr. Are we losing info?
+					filterMatch = true
+				}
+			}
+			if filterMatch {
+				owners = append(owners, owner)
+			}
+		}
+
+		if len(owners) > 0 {
+			out = append(out, &r{Path: file, Owners: owners})
+		}
+	}
+
+	return out, nil
+}

--- a/stats.go
+++ b/stats.go
@@ -1,0 +1,52 @@
+package codeowners
+
+import (
+	"sort"
+)
+
+type FilesPerOwner struct {
+	Owner      string  `json:"owner"`
+	Count      int     `json:"fileCount"`
+	Percentage float64 `json:"percentage"`
+}
+
+type OwnerStats struct {
+	TotalFiles    int
+	OwnedFiled    int
+	UnownedFiles  int
+	TotalOwners   int
+	FilesPerOwner []FilesPerOwner
+}
+
+func CalculateOwnershipStats(files Owners) OwnerStats {
+	fileCount := len(files)
+
+	stats := make(map[string]int)
+	for _, file := range files {
+		for _, owner := range file.Owners {
+			stats[owner]++
+		}
+	}
+
+	var filesPerOwner []FilesPerOwner
+	for owner, count := range stats {
+		percentage := (float64(count) / float64(fileCount)) * 100
+		filesPerOwner = append(filesPerOwner, FilesPerOwner{owner, count, percentage})
+	}
+
+	sort.Slice(filesPerOwner, func(i, j int) bool {
+		return filesPerOwner[i].Count > filesPerOwner[j].Count
+	})
+
+	unownedCount := stats["(unowned)"]
+	ownedCount := fileCount - unownedCount
+	totalOwners := len(stats) - 1
+
+	return OwnerStats{
+		TotalFiles:    fileCount,
+		OwnedFiled:    ownedCount,
+		UnownedFiles:  unownedCount,
+		FilesPerOwner: filesPerOwner,
+		TotalOwners:   totalOwners,
+	}
+}

--- a/stats.go
+++ b/stats.go
@@ -40,7 +40,10 @@ func CalculateOwnershipStats(files Owners) OwnerStats {
 
 	unownedCount := stats["(unowned)"]
 	ownedCount := fileCount - unownedCount
-	totalOwners := len(stats) - 1
+	totalOwners := len(stats)
+	if _, hasUnowned := stats["(unowned)"]; hasUnowned {
+		totalOwners--
+	}
 
 	return OwnerStats{
 		TotalFiles:    fileCount,

--- a/stats.go
+++ b/stats.go
@@ -35,6 +35,10 @@ func CalculateOwnershipStats(files Owners) OwnerStats {
 	}
 
 	sort.Slice(filesPerOwner, func(i, j int) bool {
+		countsEqual := filesPerOwner[i].Count == filesPerOwner[j].Count
+		if countsEqual {
+			return filesPerOwner[i].Owner > filesPerOwner[j].Owner
+		}
 		return filesPerOwner[i].Count > filesPerOwner[j].Count
 	})
 

--- a/stats.go
+++ b/stats.go
@@ -14,7 +14,7 @@ type OwnerStats struct {
 	TotalFiles    int             `json:"totalFiles"`
 	OwnedFiles    int             `json:"ownedFiles"`
 	UnownedFiles  int             `json:"unownedFiles"`
-	TotalOwners   int             `json:"totalOwners"`
+	OwnerCount    int             `json:"ownerCount"`
 	FilesPerOwner []FilesPerOwner `json:"filesPerOwner"`
 }
 
@@ -54,6 +54,6 @@ func CalculateOwnershipStats(files Owners) OwnerStats {
 		OwnedFiles:    ownedCount,
 		UnownedFiles:  unownedCount,
 		FilesPerOwner: filesPerOwner,
-		TotalOwners:   totalOwners,
+		OwnerCount:    totalOwners,
 	}
 }

--- a/stats.go
+++ b/stats.go
@@ -12,7 +12,7 @@ type FilesPerOwner struct {
 
 type OwnerStats struct {
 	TotalFiles    int
-	OwnedFiled    int
+	OwnedFiles    int
 	UnownedFiles  int
 	TotalOwners   int
 	FilesPerOwner []FilesPerOwner
@@ -47,7 +47,7 @@ func CalculateOwnershipStats(files Owners) OwnerStats {
 
 	return OwnerStats{
 		TotalFiles:    fileCount,
-		OwnedFiled:    ownedCount,
+		OwnedFiles:    ownedCount,
 		UnownedFiles:  unownedCount,
 		FilesPerOwner: filesPerOwner,
 		TotalOwners:   totalOwners,

--- a/stats.go
+++ b/stats.go
@@ -11,11 +11,11 @@ type FilesPerOwner struct {
 }
 
 type OwnerStats struct {
-	TotalFiles    int
-	OwnedFiles    int
-	UnownedFiles  int
-	TotalOwners   int
-	FilesPerOwner []FilesPerOwner
+	TotalFiles    int             `json:"totalFiles"`
+	OwnedFiles    int             `json:"ownedFiles"`
+	UnownedFiles  int             `json:"unownedFiles"`
+	TotalOwners   int             `json:"totalOwners"`
+	FilesPerOwner []FilesPerOwner `json:"filesPerOwner"`
 }
 
 func CalculateOwnershipStats(files Owners) OwnerStats {

--- a/stats_test.go
+++ b/stats_test.go
@@ -19,7 +19,7 @@ func TestCalculateOwnershipStats(t *testing.T) {
 				TotalFiles:    0,
 				OwnedFiles:    0,
 				UnownedFiles:  0,
-				TotalOwners:   0,
+				OwnerCount:    0,
 				FilesPerOwner: []FilesPerOwner{},
 			},
 		},
@@ -35,7 +35,7 @@ func TestCalculateOwnershipStats(t *testing.T) {
 				TotalFiles:   1,
 				OwnedFiles:   1,
 				UnownedFiles: 0,
-				TotalOwners:  1,
+				OwnerCount:   1,
 				FilesPerOwner: []FilesPerOwner{
 					{
 						Owner:      "@teamA",
@@ -57,7 +57,7 @@ func TestCalculateOwnershipStats(t *testing.T) {
 				TotalFiles:   1,
 				OwnedFiles:   0,
 				UnownedFiles: 1,
-				TotalOwners:  0,
+				OwnerCount:   0,
 				FilesPerOwner: []FilesPerOwner{
 					{
 						Owner:      "(unowned)",
@@ -87,7 +87,7 @@ func TestCalculateOwnershipStats(t *testing.T) {
 				TotalFiles:   3,
 				OwnedFiles:   2,
 				UnownedFiles: 1,
-				TotalOwners:  2,
+				OwnerCount:   2,
 				FilesPerOwner: []FilesPerOwner{
 					{
 						Owner:      "@teamA",
@@ -116,7 +116,7 @@ func TestCalculateOwnershipStats(t *testing.T) {
 			assert.Equal(t, tt.expected.TotalFiles, result.TotalFiles)
 			assert.Equal(t, tt.expected.OwnedFiles, result.OwnedFiles)
 			assert.Equal(t, tt.expected.UnownedFiles, result.UnownedFiles)
-			assert.Equal(t, tt.expected.TotalOwners, result.TotalOwners)
+			assert.Equal(t, tt.expected.OwnerCount, result.OwnerCount)
 
 			// For FilesPerOwner, we need to check each field separately due to floating point comparison
 			assert.Equal(t, len(tt.expected.FilesPerOwner), len(result.FilesPerOwner))

--- a/stats_test.go
+++ b/stats_test.go
@@ -124,7 +124,7 @@ func TestCalculateOwnershipStats(t *testing.T) {
 				assert.Equal(t, expectedOwner.Owner, result.FilesPerOwner[i].Owner)
 				assert.Equal(t, expectedOwner.Count, result.FilesPerOwner[i].Count)
 				// Use InDelta for floating point comparison with a small delta
-				assert.InDelta(t, expectedOwner.Percentage, result.FilesPerOwner[i].Percentage, 0.01)
+				assert.InDelta(t, expectedOwner.Percentage, result.FilesPerOwner[i].Percentage, 0.009)
 			}
 		})
 	}

--- a/stats_test.go
+++ b/stats_test.go
@@ -17,7 +17,7 @@ func TestCalculateOwnershipStats(t *testing.T) {
 			files: Owners{},
 			expected: OwnerStats{
 				TotalFiles:    0,
-				OwnedFiled:    0,
+				OwnedFiles:    0,
 				UnownedFiles:  0,
 				TotalOwners:   0,
 				FilesPerOwner: []FilesPerOwner{},
@@ -33,7 +33,7 @@ func TestCalculateOwnershipStats(t *testing.T) {
 			},
 			expected: OwnerStats{
 				TotalFiles:   1,
-				OwnedFiled:   1,
+				OwnedFiles:   1,
 				UnownedFiles: 0,
 				TotalOwners:  1,
 				FilesPerOwner: []FilesPerOwner{
@@ -55,7 +55,7 @@ func TestCalculateOwnershipStats(t *testing.T) {
 			},
 			expected: OwnerStats{
 				TotalFiles:   1,
-				OwnedFiled:   0,
+				OwnedFiles:   0,
 				UnownedFiles: 1,
 				TotalOwners:  0,
 				FilesPerOwner: []FilesPerOwner{
@@ -85,7 +85,7 @@ func TestCalculateOwnershipStats(t *testing.T) {
 			},
 			expected: OwnerStats{
 				TotalFiles:   3,
-				OwnedFiled:   2,
+				OwnedFiles:   2,
 				UnownedFiles: 1,
 				TotalOwners:  2,
 				FilesPerOwner: []FilesPerOwner{
@@ -114,7 +114,7 @@ func TestCalculateOwnershipStats(t *testing.T) {
 			result := CalculateOwnershipStats(tt.files)
 
 			assert.Equal(t, tt.expected.TotalFiles, result.TotalFiles)
-			assert.Equal(t, tt.expected.OwnedFiled, result.OwnedFiled)
+			assert.Equal(t, tt.expected.OwnedFiles, result.OwnedFiles)
 			assert.Equal(t, tt.expected.UnownedFiles, result.UnownedFiles)
 			assert.Equal(t, tt.expected.TotalOwners, result.TotalOwners)
 

--- a/stats_test.go
+++ b/stats_test.go
@@ -1,0 +1,131 @@
+package codeowners
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCalculateOwnershipStats(t *testing.T) {
+	tests := []struct {
+		name     string
+		files    Owners
+		expected OwnerStats
+	}{
+		{
+			name:  "empty files list",
+			files: Owners{},
+			expected: OwnerStats{
+				TotalFiles:    0,
+				OwnedFiled:    0,
+				UnownedFiles:  0,
+				TotalOwners:   0,
+				FilesPerOwner: []FilesPerOwner{},
+			},
+		},
+		{
+			name: "single owned file",
+			files: Owners{
+				{
+					Path:   "file1.txt",
+					Owners: []string{"@teamA"},
+				},
+			},
+			expected: OwnerStats{
+				TotalFiles:   1,
+				OwnedFiled:   1,
+				UnownedFiles: 0,
+				TotalOwners:  1,
+				FilesPerOwner: []FilesPerOwner{
+					{
+						Owner:      "@teamA",
+						Count:      1,
+						Percentage: 100.0,
+					},
+				},
+			},
+		},
+		{
+			name: "single unowned file",
+			files: Owners{
+				{
+					Path:   "file1.txt",
+					Owners: []string{"(unowned)"},
+				},
+			},
+			expected: OwnerStats{
+				TotalFiles:   1,
+				OwnedFiled:   0,
+				UnownedFiles: 1,
+				TotalOwners:  0,
+				FilesPerOwner: []FilesPerOwner{
+					{
+						Owner:      "(unowned)",
+						Count:      1,
+						Percentage: 100.0,
+					},
+				},
+			},
+		},
+		{
+			name: "multiple files with different owners",
+			files: Owners{
+				{
+					Path:   "file1.txt",
+					Owners: []string{"@teamA", "@teamB"},
+				},
+				{
+					Path:   "file2.txt",
+					Owners: []string{"@teamA"},
+				},
+				{
+					Path:   "file3.txt",
+					Owners: []string{"(unowned)"},
+				},
+			},
+			expected: OwnerStats{
+				TotalFiles:   3,
+				OwnedFiled:   2,
+				UnownedFiles: 1,
+				TotalOwners:  2,
+				FilesPerOwner: []FilesPerOwner{
+					{
+						Owner:      "@teamA",
+						Count:      2,
+						Percentage: 66.67,
+					},
+					{
+						Owner:      "@teamB",
+						Count:      1,
+						Percentage: 33.33,
+					},
+					{
+						Owner:      "(unowned)",
+						Count:      1,
+						Percentage: 33.33,
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := CalculateOwnershipStats(tt.files)
+
+			assert.Equal(t, tt.expected.TotalFiles, result.TotalFiles)
+			assert.Equal(t, tt.expected.OwnedFiled, result.OwnedFiled)
+			assert.Equal(t, tt.expected.UnownedFiles, result.UnownedFiles)
+			assert.Equal(t, tt.expected.TotalOwners, result.TotalOwners)
+
+			// For FilesPerOwner, we need to check each field separately due to floating point comparison
+			assert.Equal(t, len(tt.expected.FilesPerOwner), len(result.FilesPerOwner))
+			for i, expectedOwner := range tt.expected.FilesPerOwner {
+				assert.Equal(t, expectedOwner.Owner, result.FilesPerOwner[i].Owner)
+				assert.Equal(t, expectedOwner.Count, result.FilesPerOwner[i].Count)
+				// Use InDelta for floating point comparison with a small delta
+				assert.InDelta(t, expectedOwner.Percentage, result.FilesPerOwner[i].Percentage, 0.01)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR adds a new command: `co stats`.

It produces ownership statistics, showing a breakdown of owned vs unowned files, and providing a sorted breakdown of file count and percentage per owner.

It supports the `--json` flag, returning an array of `{owner: string, count: int, percentage: float64}`.

If specific files or a directory are passed in, analysis is constrained to the input.