### PR TITLE
[parse] allow Next.js route-group parentheses

### DIFF
--- a/parse.go
+++ b/parse.go
@@ -175,7 +175,7 @@ func isAlphanumeric(ch rune) bool {
 // isPatternChar matches characters that are allowed in patterns
 func isPatternChar(ch rune) bool {
 	switch ch {
-	case '*', '?', '.', '/', '@', '_', '+', '-', '\\':
+	case '*', '?', '.', '/', '@', '_', '+', '-', '\\', '(', ')':
 		return true
 	}
 	return isAlphanumeric(ch)

--- a/parse_test.go
+++ b/parse_test.go
@@ -208,6 +208,15 @@ func TestParseRule(t *testing.T) {
 				trailingComment: "",
 			}},
 		},
+		{
+			name: "pattern with parentheses (Next.js route groups)",
+			rule: "src/app/(nonauth)/forgot/**/* @user",
+			expected: []Rule{{
+				SourceLine: 1,
+				pattern:    mustBuildPattern(t, "src/app/(nonauth)/forgot/**/*"),
+				Owners:     []string{"@user"},
+			}},
+		},
 
 		// Error cases
 


### PR DESCRIPTION
## Summary
- Permit `(` and `)` in `isPatternChar` so CODEOWNERS patterns can match Next.js route-group folders like `src/app/(nonauth)/forgot/**/*`.
- Adds a parse test covering the route-group case.

Follows the same precedent as the recent square-brackets change (dbad96a) for Next.js dynamic-param folders.

## Test plan
- [x] `go test ./...` passes
- [x] Verified `co lint` against a real CODEOWNERS file containing `(nonauth)` no longer errors at the offending line.